### PR TITLE
feat: Add typeorm sample for javascript

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -17,6 +17,8 @@ jobs:
         module:
           - name: 'mysql2'
             with_oceanbase_container: true
+          - name: 'typeorm'
+            with_oceanbase_container: true
     uses: ./.github/workflows/basic-workflow.yml
     with:
       language: 'javascript'

--- a/javascript/typeorm/README-CN.md
+++ b/javascript/typeorm/README-CN.md
@@ -1,0 +1,59 @@
+# 使用 TypeORM 连接 OceanBase
+
+[English](README.md) | 简体中文
+
+本文介绍如何通过 [TypeORM](https://typeorm.io) 连接 [OceanBase](https://www.oceanbase.com) 数据库。
+
+## 准备工作
+
+确保 Node.js 和 npm 已经安装。
+
+## 项目使用
+
+拉取项目并进入相应目录:
+
+```bash
+git clone git@github.com:oceanbase/ob-samples.git
+cd javascript/typeorm
+```
+
+安装依赖:
+
+```bash
+npm install
+```
+
+修改 `index.ts` 中的数据库连接串:
+
+```javascript
+const dataSource = new DataSource({
+  type: "mysql",
+  url: "mysql://root:@127.0.0.1:2881/test",
+  entities: [User],
+  synchronize: true,
+});
+```
+
+执行 `index.ts`:
+
+```bash
+npx ts-node index.ts
+```
+
+输出以下内容，说明执行成功:
+
+```bash
+[ User { id: 1, email: 'alice@oceanbase.com', name: 'Alice' } ]
+```
+
+查看对应的 `users` 表，数据已正常插入:
+
+```bash
+mysql> select * from users;
++----+---------------------+-------+
+| id | email               | name  |
++----+---------------------+-------+
+|  1 | alice@oceanbase.com | Alice |
++----+---------------------+-------+
+1 row in set (0.01 sec)
+```

--- a/javascript/typeorm/README.md
+++ b/javascript/typeorm/README.md
@@ -1,0 +1,59 @@
+# Connect to OceanBase with TypeORM
+
+English | [简体中文](README-CN.md)
+
+This document describes how to connect to [OceanBase](https://www.oceanbase.com) with [TypeORM](https://typeorm.io).
+
+## Preparation
+
+Make sure `Node.js` and `npm` are installed.
+
+## Usage
+
+Clone the project and navigate to the appropriate directory:
+
+```bash
+git clone git@github.com:oceanbase/ob-samples.git
+cd javascript/typeorm
+```
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Modify the connection string in the `index.ts` file:
+
+```javascript
+const dataSource = new DataSource({
+  type: "mysql",
+  url: "mysql://root:@127.0.0.1:2881/test",
+  entities: [User],
+  synchronize: true,
+});
+```
+
+Execute `index.ts`:
+
+```bash
+npx ts-node index.ts
+```
+
+The output should be as follows, indicating successful execution:
+
+```bash
+[ User { id: 1, email: 'alice@oceanbase.com', name: 'Alice' } ]
+```
+
+Check the corresponding `users` table and the data has been inserted:
+
+```bash
+mysql> select * from users;
++----+---------------------+-------+
+| id | email               | name  |
++----+---------------------+-------+
+|  1 | alice@oceanbase.com | Alice |
++----+---------------------+-------+
+1 row in set (0.01 sec)
+```

--- a/javascript/typeorm/index.ts
+++ b/javascript/typeorm/index.ts
@@ -1,0 +1,40 @@
+import { DataSource } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn } from "typeorm";
+import "reflect-metadata";
+
+@Entity({ name: "users" })
+export default class User {
+  @Column()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  name: string;
+}
+
+const dataSource = new DataSource({
+  type: "mysql",
+  url: "mysql://root:@127.0.0.1:2881/test",
+  entities: [User],
+  synchronize: true,
+});
+
+dataSource
+  .initialize()
+  .then(async () => {
+    const userRepository = dataSource.getRepository(User);
+    await userRepository.save({
+      name: "Alice",
+      email: "alice@oceanbase.com",
+    });
+    const allUsers = await userRepository.find();
+    console.log(allUsers);
+    dataSource.destroy();
+  })
+  .catch((err) => {
+    console.error(err);
+    dataSource.destroy();
+  });

--- a/javascript/typeorm/package.json
+++ b/javascript/typeorm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "typeorm",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "mysql2": "^3.11.3",
+    "reflect-metadata": "^0.2.2",
+    "typeorm": "^0.3.20"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/javascript/typeorm/run.sh
+++ b/javascript/typeorm/run.sh
@@ -1,0 +1,2 @@
+npm install
+npx ts-node index.ts

--- a/javascript/typeorm/tsconfig.json
+++ b/javascript/typeorm/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
- Ref: #16

---

# Connect to OceanBase with TypeORM

This document describes how to connect to [OceanBase](https://www.oceanbase.com) with [TypeORM](https://typeorm.io).

## Preparation

Make sure `Node.js` and `npm` are installed.

## Usage

Clone the project and navigate to the appropriate directory:

```bash
git clone git@github.com:oceanbase/ob-samples.git
cd javascript/typeorm
```

Install dependencies:

```bash
npm install
```

Modify the connection string in the `index.ts` file:

```javascript
const dataSource = new DataSource({
  type: "mysql",
  url: "mysql://root:@127.0.0.1:2881/test",
  entities: [User],
  synchronize: true,
});
```

Execute `index.ts`:

```bash
npx ts-node index.ts
```

The output should be as follows, indicating successful execution:

```bash
[ User { id: 1, email: 'alice@oceanbase.com', name: 'Alice' } ]
```

Check the corresponding `users` table and the data has been inserted:

```bash
mysql> select * from users;
+----+---------------------+-------+
| id | email               | name  |
+----+---------------------+-------+
|  1 | alice@oceanbase.com | Alice |
+----+---------------------+-------+
1 row in set (0.01 sec)
```


