### PR TITLE
feat: Add drizzle sample for javascript

### DIFF
--- a/.github/workflows/basic-workflow.yml
+++ b/.github/workflows/basic-workflow.yml
@@ -16,6 +16,10 @@ on:
         required: false
         description: 'Whether to use a pre-deployed OceanBase container in CI workflow.'
         default: true
+      oceanbase_image_tag:
+        type: string
+        required: false
+        description: 'The tag of OceanBase CE Docker image.'
 
 concurrency:
   group: basic-ci-${{ github.event.pull_request.number || github.ref }}-${{ inputs.module }}
@@ -55,6 +59,7 @@ jobs:
         uses: oceanbase/setup-oceanbase-ce@v1
         with:
           network: 'host'
+          image_tag: ${{ inputs.oceanbase_image_tag || 'latest' }}
       - name: Run sample for ${{ inputs.module }}
         run: |
           cd ${{ inputs.language }}/${{ inputs.module }} || exit

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -17,8 +17,12 @@ jobs:
         module:
           - name: 'mysql2'
             with_oceanbase_container: true
+          - name: 'drizzle'
+            with_oceanbase_container: true
+            oceanbase_image_tag: '4.2.3_BETA'
     uses: ./.github/workflows/basic-workflow.yml
     with:
       language: 'javascript'
       module: ${{ matrix.module.name }}
       with_oceanbase_container: ${{ matrix.module.with_oceanbase_container }}
+      oceanbase_image_tag: ${{ matrix.module.oceanbase_image_tag }}

--- a/javascript/drizzle/.env
+++ b/javascript/drizzle/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="mysql://root:@127.0.0.1:2881/test"

--- a/javascript/drizzle/README-CN.md
+++ b/javascript/drizzle/README-CN.md
@@ -1,0 +1,60 @@
+# 使用 Drizzle 连接 OceanBase
+
+[English](README.md) | 简体中文
+
+本文介绍如何通过 [Drizzle](https://orm.drizzle.team) 连接 [OceanBase](https://www.oceanbase.com) 数据库。
+
+## 准备工作
+
+确保 Node.js 和 npm 已经安装。
+
+## 项目使用
+
+拉取项目并进入相应目录:
+
+```bash
+git clone git@github.com:oceanbase/ob-samples.git
+cd javascript/drizzle
+```
+
+安装依赖:
+
+```bash
+npm install
+```
+
+修改 `.env` 中的数据库连接串:
+
+```bash
+DATABASE_URL="mysql://root:@127.0.0.1:2881/test"
+```
+
+将 `db/schema.ts` 中定义的 `users` 模型同步到数据库中:
+
+```bash
+npx drizzle-kit push
+```
+
+执行 `index.ts` 中的示例代码:
+
+```bash
+npx ts-node index.ts
+```
+
+输出以下内容，说明执行成功:
+
+```bash
+[ { id: 1, email: 'alice@oceanbase.com', name: 'Alice' } ]
+```
+
+查看对应的 `users` 表，数据已正常插入:
+
+```bash
+mysql> select * from users;
++----+---------------------+-------+
+| id | email               | name  |
++----+---------------------+-------+
+|  1 | alice@oceanbase.com | Alice |
++----+---------------------+-------+
+1 row in set (0.01 sec)
+```

--- a/javascript/drizzle/README.md
+++ b/javascript/drizzle/README.md
@@ -1,0 +1,60 @@
+# Connect to OceanBase with Drizzle
+
+English | [简体中文](README-CN.md)
+
+This document describes how to connect to [OceanBase](https://www.oceanbase.com) with [Drizzle](https://orm.drizzle.team).
+
+## Preparation
+
+Make sure `Node.js` and `npm` are installed.
+
+## Usage
+
+Clone the project and navigate to the appropriate directory:
+
+```bash
+git clone git@github.com:oceanbase/ob-samples.git
+cd javascript/drizzle
+```
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Modify the connection string in the `.env` file:
+
+```bash
+DATABASE_URL="mysql://root:@127.0.0.1:2881/test"
+```
+
+Synchronize the `users` model defined in `db/schema.ts` to the database:
+
+```bash
+npx drizzle-kit push
+```
+
+Execute `index.ts`:
+
+```bash
+npx ts-node index.ts
+```
+
+The output should be as follows, indicating successful execution:
+
+```bash
+[ { id: 1, email: 'alice@oceanbase.com', name: 'Alice' } ]
+```
+
+Check the corresponding `users` table and the data has been inserted:
+
+```bash
+mysql> select * from users;
++----+---------------------+-------+
+| id | email               | name  |
++----+---------------------+-------+
+|  1 | alice@oceanbase.com | Alice |
++----+---------------------+-------+
+1 row in set (0.01 sec)
+```

--- a/javascript/drizzle/db/schema.ts
+++ b/javascript/drizzle/db/schema.ts
@@ -1,0 +1,7 @@
+import { mysqlTable, bigint, varchar } from "drizzle-orm/mysql-core";
+
+export const usersTable = mysqlTable("users", {
+  id: bigint({ mode: "bigint" }).autoincrement().primaryKey(),
+  email: varchar({ length: 255 }).notNull().unique(),
+  name: varchar({ length: 255 }).notNull(),
+});

--- a/javascript/drizzle/drizzle.config.ts
+++ b/javascript/drizzle/drizzle.config.ts
@@ -1,0 +1,11 @@
+import "dotenv/config";
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  out: "./drizzle",
+  schema: "./db/schema.ts",
+  dialect: "mysql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/javascript/drizzle/index.ts
+++ b/javascript/drizzle/index.ts
@@ -1,0 +1,24 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/mysql2";
+import { usersTable } from "./db/schema";
+
+const db = drizzle(process.env.DATABASE_URL!);
+
+async function main() {
+  const user: typeof usersTable.$inferInsert = {
+    name: "Alice",
+    email: "alice@oceanbase.com",
+  };
+  await db.insert(usersTable).values(user);
+
+  const allUsers = await db.select().from(usersTable);
+  console.log(allUsers);
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.log(err);
+  });

--- a/javascript/drizzle/package.json
+++ b/javascript/drizzle/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "drizzle",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "drizzle-orm": "^0.36.0",
+    "mysql2": "^3.11.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.5",
+    "drizzle-kit": "^0.27.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/javascript/drizzle/run.sh
+++ b/javascript/drizzle/run.sh
@@ -1,0 +1,4 @@
+npm install
+npx drizzle-kit generate --name=init
+npx drizzle-kit migrate
+npx ts-node index.ts

--- a/javascript/drizzle/tsconfig.json
+++ b/javascript/drizzle/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
- Ref: #16

---

# Connect to OceanBase with Drizzle

This document describes how to connect to [OceanBase](https://www.oceanbase.com) with [Drizzle](https://orm.drizzle.team).

## Preparation

Make sure `Node.js` and `npm` are installed.

## Usage

Clone the project and navigate to the appropriate directory:

```bash
git clone git@github.com:oceanbase/ob-samples.git
cd javascript/drizzle
```

Install dependencies:

```bash
npm install
```

Modify the connection string in the `.env` file:

```bash
DATABASE_URL="mysql://root:@127.0.0.1:2881/test"
```

Synchronize the `users` model defined in `db/schema.ts` to the database:

```bash
npx drizzle-kit push
```

Execute `index.ts`:

```bash
npx ts-node index.ts
```

The output should be as follows, indicating successful execution:

```bash
[ { id: 1, email: 'alice@oceanbase.com', name: 'Alice' } ]
```

Check the corresponding `users` table and the data has been inserted:

```bash
mysql> select * from users;
+----+---------------------+-------+
| id | email               | name  |
+----+---------------------+-------+
|  1 | alice@oceanbase.com | Alice |
+----+---------------------+-------+
1 row in set (0.01 sec)
```
